### PR TITLE
feat: add ArtisanMake tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ We recommend you ship an `mcp.json` file with your project in `.cursor/mcp.json`
 - List artisan commands
 - List available config() keys (and optionally values) in dot notation
 - List available env() keys (without leaking secrets of course)
+- Execute `artisan make:*` commands to generate Laravel classes
 
 ## Extra functionality
 

--- a/config/croft.php
+++ b/config/croft.php
@@ -8,6 +8,7 @@ return [
         \Croft\Resources\ListPackages::class,
     ],
     'tools' => [
+        \Croft\Tools\ArtisanMake::class,
         \Croft\Tools\CreateCroftTool::class,
         \Croft\Tools\CreateCroftResource::class,
         \Croft\Tools\ListArtisanCommands::class,

--- a/src/Tools/ArtisanMake.php
+++ b/src/Tools/ArtisanMake.php
@@ -60,12 +60,12 @@ class ArtisanMake extends AbstractTool
         $className = $arguments['name'];
         $options = (array) ($arguments['options'] ?? []);
 
-        $availableMakeTypes = $this->getAvailableArtisanMakeTypes();
+        $availableArtisanMakeTypes = $this->getAvailableArtisanMakeTypes();
 
-        if (! $availableMakeTypes->contains($classType)) {
-            $availableTypesString = $availableMakeTypes->implode(', ');
+        if (! $availableArtisanMakeTypes->contains($classType)) {
+            $availableTypesString = $availableArtisanMakeTypes->implode(', ');
 
-            return ToolResponse::text("Error: Invalid class type '{$classType}'. Available types for artisan make command are: {$availableTypesString}.");
+            return ToolResponse::error("Invalid class type '{$classType}'. Available types for the artisan make command are: {$availableTypesString}.");
         }
 
         $command = "make:{$classType}";
@@ -78,7 +78,7 @@ class ArtisanMake extends AbstractTool
 
             return ToolResponse::text($output);
         } catch (\Exception $e) {
-            return ToolResponse::text('Error executing command: '.$e->getMessage());
+            return ToolResponse::error('Error executing command: '.$e->getMessage());
         }
     }
 

--- a/src/Tools/ArtisanMake.php
+++ b/src/Tools/ArtisanMake.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Croft\Tools;
+
+use Croft\Feature\Tool\AbstractTool;
+use Croft\Feature\Tool\ToolResponse;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Artisan;
+
+class ArtisanMake extends AbstractTool
+{
+    public function __construct()
+    {
+        $this->setTitle('artisan_make')
+            ->setReadOnly(false)
+            ->setDestructive(false)
+            ->setIdempotent(false);
+    }
+
+    public function getName(): string
+    {
+        return 'artisan_make';
+    }
+
+    public function getDescription(): string
+    {
+        return 'Generates Laravel classes using the artisan make command. Available class types: '.$this->getAvailableArtisanMakeTypes()->implode(', ');
+    }
+
+    /**
+     * What params does the MCP client need to provide to use this tool?
+     **/
+    public function getInputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => (object) [
+                'type' => [
+                    'type' => 'string',
+                    'description' => 'The type of class to create (e.g., controller, model, job).',
+                ],
+                'name' => [
+                    'type' => 'string',
+                    'description' => 'The name of the class to create.',
+                ],
+                'options' => [
+                    'type' => 'object',
+                    'description' => 'Additional options for the make command (e.g., {"--invokable": true}).',
+                ],
+            ],
+            'required' => ['type', 'name'],
+        ];
+    }
+
+    public function handle(array $arguments): ToolResponse
+    {
+        $classType = $arguments['type'];
+        $className = $arguments['name'];
+        $options = (array) ($arguments['options'] ?? []);
+
+        $availableMakeTypes = $this->getAvailableArtisanMakeTypes();
+
+        if (! $availableMakeTypes->contains($classType)) {
+            $availableTypesString = $availableMakeTypes->implode(', ');
+
+            return ToolResponse::text("Error: Invalid class type '{$classType}'. Available types for artisan make command are: {$availableTypesString}.");
+        }
+
+        $command = "make:{$classType}";
+
+        $params = array_merge(['name' => $className], $options);
+
+        try {
+            Artisan::call($command, $params);
+            $output = Artisan::output();
+
+            return ToolResponse::text($output);
+        } catch (\Exception $e) {
+            return ToolResponse::text('Error executing command: '.$e->getMessage());
+        }
+    }
+
+    private function getAvailableArtisanMakeTypes(): Collection
+    {
+        return collect(Artisan::all())
+            ->keys()
+            ->filter(fn (string $command) => str_starts_with($command, 'make:'))
+            ->map(fn (string $command) => str_replace('make:', '', $command))
+            ->sort()
+            ->values();
+    }
+}

--- a/tests/Tools/ArtisanMakeTest.php
+++ b/tests/Tools/ArtisanMakeTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+use Croft\Feature\Tool\ToolResponse;
+use Croft\Tools\ArtisanMake;
+use Illuminate\Support\Facades\Artisan;
+
+beforeEach(function () {
+    $this->tool = new ArtisanMake;
+});
+
+it('can execute artisan make command', function () {
+    // Arrange
+    $mock = \Mockery::mock(Artisan::getFacadeRoot());
+    $mock->shouldReceive('all')->andReturn([
+        'make:controller' => 'Make a controller',
+    ]);
+    $mock->shouldReceive('call')
+        ->with('make:controller', ['name' => 'TestController'])
+        ->andReturn(0);
+    $mock->shouldReceive('output')->andReturn('Controller created successfully.');
+
+    Artisan::swap($mock);
+
+    // Act
+    $response = $this->tool->handle([
+        'type' => 'controller',
+        'name' => 'TestController',
+    ]);
+
+    // Assert
+    expect($response)
+        ->toBeInstanceOf(ToolResponse::class)
+        ->toEqual(ToolResponse::text('Controller created successfully.'));
+});
+
+it('handles invalid class type', function () {
+    // Arrange
+    $mock = Mockery::mock(Artisan::getFacadeRoot());
+    $mock->shouldReceive('all')->andReturn([
+        'make:controller' => 'Make a controller',
+    ]);
+
+    Artisan::swap($mock);
+
+    // Act
+    $response = $this->tool->handle([
+        'type' => 'invalid-type',
+        'name' => 'TestController',
+    ]);
+
+    // Assert
+    expect($response)
+        ->toBeInstanceOf(ToolResponse::class)
+        ->toEqual(
+            ToolResponse::error("Invalid class type 'invalid-type'. Available types for the artisan make command are: controller.")
+        );
+});
+
+it('can handle artisan make command with additional options', function () {
+    // Arrange
+    $mock = \Mockery::mock(Artisan::getFacadeRoot());
+    $mock->shouldReceive('all')->andReturn([
+        'make:controller' => 'Make a controller',
+    ]);
+    $mock->shouldReceive('call')
+        ->with('make:controller', ['name' => 'TestController', '--invokable' => true])
+        ->andReturn(0);
+    $mock->shouldReceive('output')->andReturn('Invokable controller created successfully.');
+
+    Artisan::swap($mock);
+
+    // Act
+    $response = $this->tool->handle([
+        'type' => 'controller',
+        'name' => 'TestController',
+        'options' => ['--invokable' => true],
+    ]);
+
+    // Assert
+    expect($response)
+        ->toBeInstanceOf(ToolResponse::class)
+        ->toEqual(ToolResponse::text('Invokable controller created successfully.'));
+});


### PR DESCRIPTION
Adds a new tool that ensures Laravel classes are generated properly using Laravel's native artisan make commands, rather than having AI attempt to create files directly. This guarantees that all generated classes follow Laravel's conventions and best practices.

The tool:
- Uses Laravel's built-in artisan make commands
- Maintains Laravel's directory structure and naming conventions
- Supports all standard make commands (controllers, models, jobs, etc.)
- Accepts command-specific options (--invokable, --resource, etc.)